### PR TITLE
Removes setFetch helper function.

### DIFF
--- a/test/Model.test.js
+++ b/test/Model.test.js
@@ -1,4 +1,4 @@
-import {EventEmitter, Model, Collection, setFetch} from '../vertebrate.js';
+import {EventEmitter, Model, Collection} from '../vertebrate.js';
 import assert from 'assert';
 import sinon from 'sinon';
 
@@ -21,7 +21,7 @@ describe('Model', () => {
 
     fakeFetch = sandbox.stub().returns(fetchDeferred.promise);
 
-    setFetch(fakeFetch);
+    global.fetch = fakeFetch;
   });
 
   afterEach(() => sandbox.restore());

--- a/vertebrate.js
+++ b/vertebrate.js
@@ -1,10 +1,4 @@
-// Store a reference to fetch. The user can override it.
-
-let fetch;
-
-export function setFetch(altFetch) {
-  fetch = altFetch;
-}
+/* global fetch */
 
 // Utility functions start.
 


### PR DESCRIPTION
Vertebrate will assume that `fetch` is available.